### PR TITLE
Base image + .gitignore + Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.peru
+*.swp
+*.SyncOld

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+cache: apt
+
+install:
+  - sudo sh -c "wget -qO- https://get.docker.io/gpg | apt-key add -"
+  - sudo sh -c "echo deb http://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/docker.list"
+  - sudo sh -c "wget -qO- https://get.docker.io/builds/Linux/x86_64/docker-1.4.1.tgz |sudo tar zxf - -C /"
+  - sudo apt-get update
+  - sudo mkdir -p /var/lib/docker
+  - echo exit 101 | sudo tee /usr/sbin/policy-rc.d
+  - sudo chmod +x /usr/sbin/policy-rc.d
+  - sudo apt-get install -y slirp lxc aufs-tools cgroup-lite
+  - curl -sLo linux https://github.com/jpetazzo/sekexe/raw/master/uml
+  - chmod +x linux
+
+matrix:
+  fast_finish: true
+
+env:
+  - DIR=base
+
+script:
+  - ./linux quiet mem=2G rootfstype=hostfs rw eth0=slirp,,/usr/bin/slirp-fullbolt init=$(pwd)/uml.sh WORKDIR=$(pwd)/$DIR HOME=$HOME; exit `cat $(pwd)/$DIR/exit.status`

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:latest
+MAINTAINER Ofir Petrushka Rounds <ofir@rounds.com>
+
+# Solves some issues and many messages in apt-get install
+ENV DEBIAN_FRONTEND noninteractive
+
+# The cleanup presented here is repeated in many places that use apt-get install. This is used to have the cleanes image possible.
+# Pilling many commands into one RUN is used to relate to the same FS layer. (otherwise each command is done in a seperate FS which makes you write the file in one layer and delete it in another...)
+# wget and curl are something we expect in many scripts, makes sense to always have them.
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y wget curl && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# We do want to treat logs the same in all of our images.
+#VOLUME ["/var/log"] # sucks to do it so early, open issue https://github.com/docker/docker/issues/3639 volume is non-mutable between Dockerfile instruction

--- a/base/README.md
+++ b/base/README.md
@@ -1,0 +1,5 @@
+Base 10M docker
+===============
+This is the master branch of the tree, all other images inherit from it either directly or by casscade inheritance.
+
+Any change here should cause a casscase rebuild of the entire tree.

--- a/makefile
+++ b/makefile
@@ -1,0 +1,4 @@
+all:
+	peru reup -f
+	peru sync
+	sed -i "s/^docker run .*/docker build \./" uml.sh # build docker image

--- a/peru.yaml
+++ b/peru.yaml
@@ -1,0 +1,7 @@
+imports:
+    travis-docker-example: ./
+
+git module travis-docker-example:
+    url: https://github.com/lukecyca/travis-docker-example
+    pick: uml.sh
+    rev: 078d889382b4324a553813ba641e34673b6a7406

--- a/uml.sh
+++ b/uml.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# Exit on first error
+set -e
+
+
+save_and_shutdown() {
+  # save built for host result
+  # force clean shutdown
+  echo $? > $WORKDIR/exit.status
+  halt -f
+}
+
+# make sure we shut down cleanly
+trap save_and_shutdown EXIT SIGINT SIGTERM
+
+# go back to where we were invoked
+cd $WORKDIR
+
+# configure path to include /usr/local
+export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+# can't do much without proc!
+mount -t proc none /proc
+
+# pseudo-terminal devices
+mkdir -p /dev/pts
+mount -t devpts none /dev/pts
+
+# shared memory a good idea
+mkdir -p /dev/shm
+mount -t tmpfs none /dev/shm
+
+# sysfs a good idea
+mount -t sysfs none /sys
+
+# pidfiles and such like
+mkdir -p /var/run
+mount -t tmpfs none /var/run
+
+# takes the pain out of cgroups
+cgroups-mount
+
+# mount /var/lib/docker with a tmpfs
+mount -t tmpfs none /var/lib/docker
+
+# enable ipv4 forwarding for docker
+echo 1 > /proc/sys/net/ipv4/ip_forward
+
+# configure networking
+ip addr add 127.0.0.1 dev lo
+ip link set lo up
+ip addr add 10.1.1.1/24 dev eth0
+ip link set eth0 up
+ip route add default via 10.1.1.254
+
+# configure dns (google public)
+mkdir -p /run/resolvconf
+echo 'nameserver 8.8.8.8' > /run/resolvconf/resolv.conf
+mount --bind /run/resolvconf/resolv.conf /etc/resolv.conf
+
+# Start docker daemon
+docker -d &
+sleep 5
+
+# Use docker
+docker build .


### PR DESCRIPTION
Reuse docker travis tricks from github.com/lukecyca/travis-docker-example, now with returned error codes to actually fail travis (using peru + makefile + .travis..)
.travis.yml ready for multi image tests in parallel
Base docker images.
Initial .gitignore

@rounds/server 